### PR TITLE
Fix --{exclude,extensions} parsing.

### DIFF
--- a/bin/terminal_velocity
+++ b/bin/terminal_velocity
@@ -55,13 +55,13 @@ the default default will be used"""
         help="the filename extension for new notes (default: %(default)s)")
 
     parser.add_argument("--extensions", dest="extensions", action="store",
-        nargs='+', default=defaults.get("extensions",
+        default=defaults.get("extensions",
             ".txt, .text, .md, .markdown, .mdown, .mdwn, .mkdn, .mkd, .rst"),
         help="the filename extensions to recognize in the notes dir, a "
             "comma-separated list (default: %(default)s)")
 
     parser.add_argument("--exclude", dest="exclude", action="store",
-        nargs='+', default=defaults.get("exclude",
+        default=defaults.get("exclude",
             "src, backup, ignore, tmp, old"),
         help="the file/directory names to skip while recursively searching "
             "the notes dir for notes, a comma-separated list "


### PR DESCRIPTION
Currently, use of --exclude or --extensions results in,

    Traceback (most recent call last):
      File "bin/terminal_velocity", line 129, in <module>
        main()
      File "bin/terminal_velocity", line 89, in main
        for extension in args.extensions.split(","):
    AttributeError: 'list' object has no attribute 'split'

This is because `nargs='+'` tells argparse to produce the result as a list.
However, args.exclude and args.extensions are expected to be strings
containing comma-separated values.

This PR fixes the issue.