### PR TITLE
Wrap target note path in quotes for shell compatibility

### DIFF
--- a/terminal_velocity/urwid_ui.py
+++ b/terminal_velocity/urwid_ui.py
@@ -9,7 +9,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 import urwid
-
 import notebook
 
 
@@ -323,16 +322,16 @@ class MainFrame(urwid.Frame):
 
         elif key in ["enter"]:
             if self.selected_note:
-                system(self.editor + ' ' + self.selected_note.abspath, self.loop)
+                system(self.editor + " '" + self.selected_note.abspath + "'", self.loop)
             else:
                 if self.search_box.edit_text:
                     try:
                         note = self.notebook.add_new(self.search_box.edit_text)
-                        system(self.editor + ' ' + note.abspath, self.loop)
+                        system(self.editor + " '" + note.abspath + "'", self.loop)
                     except notebook.NoteAlreadyExistsError:
                         # Try to open the existing note instead.
-                        system(self.editor + ' ' + self.search_box.edit_text +
-                                self.notebook.extension,
+                        system(self.editor + " '" + self.search_box.edit_text +
+                                self.notebook.extension + "'",
                             self.loop)
                     except notebook.InvalidNoteTitleError:
                         # TODO: Display error message to user.


### PR DESCRIPTION
Hi,

Here we are improving notebook name path compatibility for shell usage. Currently spaces in filenames cause the application to open up a file with just the first word. For example, if we create a note named "Github Tutorial". The following command will be passed to the shell and ran `vim Github Tutorial` and not `vim Github\ Tutorial`. Such creates two separate files. Wrapping in single quotes helps with this. 

Thanks.

Vincent